### PR TITLE
Changed default shuffle state

### DIFF
--- a/app/src/main/kotlin/org/fossify/musicplayer/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/helpers/Config.kt
@@ -10,7 +10,7 @@ class Config(context: Context) : BaseConfig(context) {
     }
 
     var isShuffleEnabled: Boolean
-        get() = prefs.getBoolean(SHUFFLE, true)
+        get() = prefs.getBoolean(SHUFFLE, false)
         set(shuffle) = prefs.edit().putBoolean(SHUFFLE, shuffle).apply()
 
     var playbackSetting: PlaybackSetting


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
Currently, shuffle was set to be turned on by default, what's misleading after running the app for the first time.  It can lead to questions like these: https://github.com/FossifyOrg/Music-Player/discussions/20, since it's not the behavior users expect. I don't know any other music player that turns shuffle by default.

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Music-Player/blob/master/CONTRIBUTING.md).
