### PR TITLE
Changed the previous button behavior (#45)

### DIFF
--- a/app/src/main/kotlin/org/fossify/musicplayer/helpers/MyWidgetProvider.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/helpers/MyWidgetProvider.kt
@@ -60,7 +60,7 @@ class MyWidgetProvider : AppWidgetProvider() {
             } else {
                 when (action) {
                     NEXT -> player.seekToNextMediaItem()
-                    PREVIOUS -> player.seekToPreviousMediaItem()
+                    PREVIOUS -> if (player.contentPosition > 5000) player.seekTo(0) else player.seekToPreviousMediaItem()
                     PLAYPAUSE -> player.togglePlayback()
                 }
             }

--- a/app/src/main/kotlin/org/fossify/musicplayer/playback/player/SimpleMusicPlayer.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/playback/player/SimpleMusicPlayer.kt
@@ -67,7 +67,9 @@ class SimpleMusicPlayer(private val exoPlayer: ExoPlayer) : ForwardingPlayer(exo
 
     override fun seekToPrevious() {
         play()
-        if (!maybeForcePrevious()) {
+        if (currentPosition > 5000) {
+            seekTo(0)
+        } else if (!maybeForcePrevious()) {
             seekToPreviousCount += 1
             seekWithDelay()
         }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
Changed behavior of the previous button to work like in other players:
- If the track position is during its first 5 seconds, it seeks to the previous media item.
- Otherwise, it restarts the track.

This behavior has also been added to the widget.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->

https://github.com/FossifyOrg/Music-Player/assets/85929121/059a9552-d212-4c56-91e1-c0ab89fe881f

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #45

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Music-Player/blob/master/CONTRIBUTING.md).
