### PR TITLE
Feat/skip uses wrong button icon

### DIFF
--- a/app/src/main/res/drawable/ic_next_vector.xml
+++ b/app/src/main/res/drawable/ic_next_vector.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M660,720v-480h80v480h-80ZM220,720v-480l360,240 -360,240Z"
+      android:fillColor="#5f6368"/>
+</vector>

--- a/app/src/main/res/drawable/ic_next_vector.xml
+++ b/app/src/main/res/drawable/ic_next_vector.xml
@@ -1,9 +1,3 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="960"
-    android:viewportHeight="960">
-  <path
-      android:pathData="M660,720v-480h80v480h-80ZM220,720v-480l360,240 -360,240Z"
-      android:fillColor="#5f6368"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="960" android:viewportHeight="960">
+<path android:fillColor="#FF000000" android:pathData="M660 720V240h80v480h-80zm-440 0V240l360 240-360 240z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_previous_vector.xml
+++ b/app/src/main/res/drawable/ic_previous_vector.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M220,720v-480h80v480h-80ZM740,720L380,480l360,-240v480Z"
+      android:fillColor="#5f6368"/>
+</vector>

--- a/app/src/main/res/drawable/ic_previous_vector.xml
+++ b/app/src/main/res/drawable/ic_previous_vector.xml
@@ -1,9 +1,3 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="960"
-    android:viewportHeight="960">
-  <path
-      android:pathData="M220,720v-480h80v480h-80ZM740,720L380,480l360,-240v480Z"
-      android:fillColor="#5f6368"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="960" android:viewportHeight="960">
+<path android:fillColor="#FF000000" android:pathData="M220 720V240h80v480h-80zm520 0L380 480l360-240v480z"/>
 </vector>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
-- update icons
-- formatted icon with (avocado : https://github.com/alexjlockwood/avocado)

#### Before/After Screenshots/Screen Record
- Before:
![Screenshot_20240427_220513BEFORE](https://github.com/FossifyOrg/Music-Player/assets/95193272/0c6b0d63-2bfa-4e7e-9de2-ee256012f319)
- After:
![Screenshot_skip_button_icon](https://github.com/FossifyOrg/Music-Player/assets/95193272/7f05378e-0bd7-47cd-ba9e-a47bbe66a455)

