### PR TITLE
Fixed handling empty track number (#47)

### DIFF
--- a/app/src/main/kotlin/org/fossify/musicplayer/adapters/TracksHeaderAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/adapters/TracksHeaderAdapter.kt
@@ -133,9 +133,10 @@ class TracksHeaderAdapter(activity: SimpleActivity, items: ArrayList<ListItem>, 
 
             trackDuration.text = track.duration.getFormattedDuration()
             if (track.discNumber != null) {
-                trackId.text = context.getString(R.string.track_on_disk, track.discNumber, track.trackId.toString().padStart(2, '0'))
+                val trackNumber = if (track.trackId != null) track.trackId.toString().padStart(2, '0') else ""
+                trackId.text = context.getString(R.string.track_on_disk, track.discNumber, trackNumber)
             } else {
-                trackId.text = track.trackId.toString()
+                trackId.text = if (track.trackId != null) track.trackId.toString() else ""
             }
             trackImage.beGone()
             trackId.beVisible()

--- a/app/src/main/kotlin/org/fossify/musicplayer/databases/SongsDatabase.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/databases/SongsDatabase.kt
@@ -10,7 +10,7 @@ import org.fossify.musicplayer.interfaces.*
 import org.fossify.musicplayer.models.*
 import org.fossify.musicplayer.objects.MyExecutor
 
-@Database(entities = [Track::class, Playlist::class, QueueItem::class, Artist::class, Album::class, Genre::class], version = 14)
+@Database(entities = [Track::class, Playlist::class, QueueItem::class, Artist::class, Album::class, Genre::class], version = 15)
 abstract class SongsDatabase : RoomDatabase() {
 
     abstract fun SongsDao(): SongsDao
@@ -47,6 +47,7 @@ abstract class SongsDatabase : RoomDatabase() {
                             .addMigrations(MIGRATION_11_12)
                             .addMigrations(MIGRATION_12_13)
                             .addMigrations(MIGRATION_13_14)
+                            .addMigrations(MIGRATION_14_15)
                             .build()
                     }
                 }
@@ -207,6 +208,27 @@ abstract class SongsDatabase : RoomDatabase() {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.apply {
                     execSQL("ALTER TABLE tracks ADD COLUMN disc_number INTEGER DEFAULT NULL")
+                }
+            }
+        }
+
+        private val MIGRATION_14_15 = object : Migration(14, 15) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.apply {
+                    execSQL(
+                        "CREATE TABLE tracks_new (`id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, `media_store_id` INTEGER NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `path` TEXT NOT NULL, `duration` INTEGER NOT NULL, " +
+                            "`album` TEXT NOT NULL, genre TEXT NOT NULL DEFAULT '', `cover_art` TEXT default '' NOT NULL, `playlist_id` INTEGER NOT NULL, `track_id` INTEGER DEFAULT NULL, disc_number INTEGER DEFAULT NULL, " +
+                            "folder_name TEXT default '' NOT NULL, album_id INTEGER NOT NULL DEFAULT 0, artist_id INTEGER NOT NULL DEFAULT 0, genre_id INTEGER NOT NULL DEFAULT 0, year INTEGER NOT NULL DEFAULT 0, date_added INTEGER NOT NULL DEFAULT 0, " +
+                            "order_in_playlist INTEGER NOT NULL DEFAULT 0, flags INTEGER NOT NULL DEFAULT 0)"
+                    )
+                    execSQL(
+                        "INSERT INTO tracks_new(id,media_store_id,title,artist,path,duration,album,genre,cover_art,playlist_id,track_id,disc_number,folder_name,album_id,artist_id,genre_id,year,date_added,order_in_playlist,flags) " +
+                            "SELECT id,media_store_id,title,artist,path,duration,album,genre,cover_art,playlist_id,track_id,disc_number,folder_name,album_id,artist_id,genre_id,year,date_added,order_in_playlist,flags " +
+                            "FROM tracks"
+                    )
+                    execSQL("DROP TABLE tracks")
+                    execSQL("ALTER TABLE tracks_new RENAME to tracks")
+                    execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_tracks_id` ON `tracks` (`media_store_id`, `playlist_id`)")
                 }
             }
         }

--- a/app/src/main/kotlin/org/fossify/musicplayer/extensions/MediaItem.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/extensions/MediaItem.kt
@@ -158,7 +158,7 @@ private fun createBundleFromTrack(track: Track) = bundleOf(
     EXTRA_GENRE to track.genre,
     EXTRA_COVER_ART to track.coverArt,
     EXTRA_PLAYLIST_ID to track.playListId,
-    EXTRA_TRACK_ID to track.trackId,
+    EXTRA_TRACK_ID to (track.trackId ?: Int.MIN_VALUE),
     EXTRA_DISC_NUMBER to (track.discNumber ?: Int.MIN_VALUE),
     EXTRA_FOLDER_NAME to track.folderName,
     EXTRA_ALBUM_ID to track.albumId,
@@ -176,6 +176,11 @@ private fun createTrackFromBundle(bundle: Bundle): Track {
         discNumber = null
     }
 
+    var trackId: Int? = bundle.getInt(EXTRA_TRACK_ID)
+    if (trackId == Int.MIN_VALUE) {
+        trackId = null
+    }
+
     return Track(
         id = bundle.getLong(EXTRA_ID),
         mediaStoreId = bundle.getLong(EXTRA_MEDIA_STORE_ID),
@@ -187,7 +192,7 @@ private fun createTrackFromBundle(bundle: Bundle): Track {
         genre = bundle.getString(EXTRA_GENRE) ?: "",
         coverArt = bundle.getString(EXTRA_COVER_ART) ?: "",
         playListId = bundle.getInt(EXTRA_PLAYLIST_ID),
-        trackId = bundle.getInt(EXTRA_TRACK_ID),
+        trackId = trackId,
         discNumber = discNumber,
         folderName = bundle.getString(EXTRA_FOLDER_NAME) ?: "",
         albumId = bundle.getLong(EXTRA_ALBUM_ID),

--- a/app/src/main/kotlin/org/fossify/musicplayer/helpers/RoomHelper.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/helpers/RoomHelper.kt
@@ -97,7 +97,7 @@ class RoomHelper(val context: Context) {
 
                 val song = Track(
                     id = 0, mediaStoreId = mediaStoreId, title = title, artist = artist, path = path, duration = duration, album = album, genre = genre,
-                    coverArt = coverArt, playListId = playlistId, trackId = 0, discNumber = discNumber, folderName = folderName, albumId = albumId,
+                    coverArt = coverArt, playListId = playlistId, trackId = null, discNumber = discNumber, folderName = folderName, albumId = albumId,
                     artistId = artistId, genreId = genreId, year = year, dateAdded = dateAdded, orderInPlaylist = 0
                 )
                 song.title = song.getProperTitle(showFilename)
@@ -118,7 +118,7 @@ class RoomHelper(val context: Context) {
 
             val song = Track(
                 id = 0, mediaStoreId = 0, title = title, artist = artist, path = it, duration = context.getDuration(it) ?: 0, album = "",
-                genre = "", coverArt = "", playListId = playlistId, trackId = 0, discNumber = null, folderName = "", albumId = 0, artistId = 0,
+                genre = "", coverArt = "", playListId = playlistId, trackId = null, discNumber = null, folderName = "", albumId = 0, artistId = 0,
                 genreId = 0, year = 0, dateAdded = dateAdded, orderInPlaylist = 0
             )
             song.title = song.getProperTitle(showFilename)

--- a/app/src/main/kotlin/org/fossify/musicplayer/helpers/SimpleMediaScanner.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/helpers/SimpleMediaScanner.kt
@@ -232,7 +232,10 @@ class SimpleMediaScanner(private val context: Application) {
             val id = cursor.getLongValue(Audio.Media._ID)
             val title = cursor.getStringValue(Audio.Media.TITLE)
             val duration = cursor.getIntValue(Audio.Media.DURATION) / 1000
-            val trackId = cursor.getIntValue(Audio.Media.TRACK) % 1000
+            var trackId = cursor.getIntValueOrNull(Audio.Media.TRACK)
+            if (trackId != null) {
+                trackId %= 1000
+            }
             val path = cursor.getStringValue(Audio.Media.DATA).orEmpty()
             val artist = cursor.getStringValue(Audio.Media.ARTIST) ?: MediaStore.UNKNOWN_STRING
             val folderName = if (isQPlus()) {
@@ -445,8 +448,8 @@ class SimpleMediaScanner(private val context: Application) {
             val folderName = path.getParentPath().getFilenameFromPath()
             val album = retriever.extractMetadata(METADATA_KEY_ALBUM) ?: folderName
             val trackNumber = retriever.extractMetadata(METADATA_KEY_CD_TRACK_NUMBER)
-            val trackId = trackNumber?.split("/")?.first()?.toIntOrNull() ?: 0
-            val discNumber = retriever.extractMetadata(METADATA_KEY_DISC_NUMBER)?.toIntOrNull() ?: 0
+            val trackId = trackNumber?.split("/")?.first()?.toIntOrNull()
+            val discNumber = retriever.extractMetadata(METADATA_KEY_DISC_NUMBER)?.toIntOrNull()
             val year = retriever.extractMetadata(METADATA_KEY_YEAR)?.toIntOrNull() ?: 0
             val dateAdded = try {
                 (File(path).lastModified() / 1000L).toInt()

--- a/app/src/main/kotlin/org/fossify/musicplayer/models/Track.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/models/Track.kt
@@ -30,7 +30,7 @@ data class Track(
     @ColumnInfo(name = "genre") var genre: String,
     @ColumnInfo(name = "cover_art") val coverArt: String,
     @ColumnInfo(name = "playlist_id") var playListId: Int,
-    @ColumnInfo(name = "track_id") val trackId: Int,  // order id within the tracks' album
+    @ColumnInfo(name = "track_id") val trackId: Int?,  // order id within the tracks' album
     @ColumnInfo(name = "disc_number") var discNumber: Int?,
     @ColumnInfo(name = "folder_name") var folderName: String,
     @ColumnInfo(name = "album_id") var albumId: Long,
@@ -66,7 +66,7 @@ data class Track(
                 sorting and PLAYER_SORT_BY_TRACK_ID != 0 -> {
                     val discComparison = (first.discNumber ?: Int.MAX_VALUE).compareTo(second.discNumber ?: Int.MAX_VALUE)
                     if (discComparison == 0) {
-                        first.trackId.compareTo(second.trackId)
+                        first.trackId?.compareTo(second.trackId ?: 0) ?: 0
                     } else {
                         discComparison
                     }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- When there's no track number, `null` is saved to DB instead of `0`.
    - I've edited the same places as in https://github.com/FossifyOrg/Music-Player/pull/46 and used the same tricks (e.g. using `MIN_VALUE` when it's not possible to set `null`).
- In case of no track number, nothing is displayed (per https://github.com/FossifyOrg/Music-Player/issues/47#issuecomment-2054137334).
    - In the linked comment, there was also an idea to reduce the padding. However, the current padding works well with disc numbers, so I decided to leave it as it is.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:

<img alt="Screenshot_4" src="https://github.com/user-attachments/assets/f903eb11-7965-4219-afa4-34ad3a1bb6e5" width=180 />

- After:

<img alt="Screenshot_5" src="https://github.com/user-attachments/assets/a4efa2c8-a988-4f40-82da-7038b50529c1" width=181 />

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #47 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Music-Player/blob/master/CONTRIBUTING.md).
