### PR TITLE
fix: parse disc numbers properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Disc numbers now display correctly in multi-disc albums ([#228])
 
 ## [1.2.1] - 2025-07-16
 ### Changed
@@ -40,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#45]: https://github.com/FossifyOrg/Music-Player/issues/45
 [#47]: https://github.com/FossifyOrg/Music-Player/issues/47
 [#206]: https://github.com/FossifyOrg/Music-Player/issues/206
+[#228]: https://github.com/FossifyOrg/Music-Player/issues/228
 
 [Unreleased]: https://github.com/FossifyOrg/Music-Player/compare/1.2.1...HEAD
 [1.2.1]: https://github.com/FossifyOrg/Music-Player/compare/1.2.0...1.2.1


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- This change ensures values like `1/1`, `2/2` are parsed correctly.  `Audio.Media.DISC_NUMBER` is not guaranteed to be a plain number.

#### Before & after preview

<img width="972" height="2160" alt="image" src="https://github.com/user-attachments/assets/9d016497-af0c-42f8-8307-95a42d1e1eba" />

#### Closes the following issue(s)
- Closes https://github.com/FossifyOrg/Music-Player/issues/228

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
