### PR TITLE
fix: find current fragment using viewpager position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Playlist menu options now show up correctly on the playlists tab ([#65])
 
 ## [1.2.2] - 2025-08-21
 ### Changed
@@ -46,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#18]: https://github.com/FossifyOrg/Music-Player/issues/18
 [#45]: https://github.com/FossifyOrg/Music-Player/issues/45
 [#47]: https://github.com/FossifyOrg/Music-Player/issues/47
+[#65]: https://github.com/FossifyOrg/Music-Player/issues/65
 [#206]: https://github.com/FossifyOrg/Music-Player/issues/206
 [#228]: https://github.com/FossifyOrg/Music-Player/issues/228
 

--- a/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
@@ -118,9 +118,10 @@ class MainActivity : SimpleMusicActivity() {
         }
     }
 
-    private fun refreshMenuItems() {
+    private fun refreshMenuItems(position: Int = binding.viewPager.currentItem) {
         binding.mainMenu.getToolbar().menu.apply {
-            val isPlaylistFragment = getCurrentFragment() is PlaylistsFragment
+            val tab = getVisibleTabs()[position]
+            val isPlaylistFragment = tab == TAB_PLAYLISTS
             findItem(R.id.create_new_playlist).isVisible = isPlaylistFragment
             findItem(R.id.create_playlist_from_folder).isVisible = isPlaylistFragment
             findItem(R.id.import_playlist).isVisible = isPlaylistFragment
@@ -224,7 +225,7 @@ class MainActivity : SimpleMusicActivity() {
                 getAllFragments().forEach {
                     it.finishActMode()
                 }
-                refreshMenuItems()
+                refreshMenuItems(position)
             }
         })
         binding.viewPager.currentItem = config.lastUsedViewPagerPage


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
The `getCurrentFragment()` method doesn't always return the current fragment. Using `position` to find the current fragment ensures that the correct menu items are displayed when that happens.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Music-Player/issues/65

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
