### PR TITLE
feat: preserve search query on tab change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Search query is now preserved when switching tabs ([#261])
 - Search now ignores accents and diacritics ([#209])
 
 ## [1.2.3] - 2025-09-09
@@ -59,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#206]: https://github.com/FossifyOrg/Music-Player/issues/206
 [#228]: https://github.com/FossifyOrg/Music-Player/issues/228
 [#209]: https://github.com/FossifyOrg/Music-Player/issues/209
+[#261]: https://github.com/FossifyOrg/Music-Player/issues/261
 
 [Unreleased]: https://github.com/FossifyOrg/Music-Player/compare/1.2.3...HEAD
 [1.2.3]: https://github.com/FossifyOrg/Music-Player/compare/1.2.2...1.2.3

--- a/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
@@ -338,7 +338,7 @@ class MainActivity : SimpleMusicActivity() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, resultData: Intent?) {
         super.onActivityResult(requestCode, resultCode, resultData)
-        if (requestCode == PICK_IMPORT_SOURCE_INTENT && resultCode == RESULT_OK && resultData != null && resultData.data != null) {
+        if (requestCode == PICK_IMPORT_SOURCE_INTENT && resultCode == RESULT_OK && resultData?.data != null) {
             tryImportPlaylistFromFile(resultData.data!!)
         }
     }

--- a/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
@@ -249,7 +249,7 @@ class MainActivity : SimpleMusicActivity() {
                 binding.viewPager.currentItem = it.position
                 updateBottomTabItemColors(it.customView, true)
                 binding.viewPager.post {
-                    getAdapter()?.getCurrentFragmentAt(it.position)?.onSearchQueryChanged(
+                    getAdapter()?.getFragmentAt(it.position)?.onSearchQueryChanged(
                         text = binding.mainMenu.getCurrentQuery()
                     )
                 }

--- a/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
@@ -1,6 +1,5 @@
 package org.fossify.musicplayer.activities
 
-import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.graphics.drawable.ColorDrawable
@@ -247,9 +246,13 @@ class MainActivity : SimpleMusicActivity() {
                 updateBottomTabItemColors(it.customView, false)
             },
             tabSelectedAction = {
-                binding.mainMenu.closeSearch()
                 binding.viewPager.currentItem = it.position
                 updateBottomTabItemColors(it.customView, true)
+                binding.viewPager.post {
+                    getAdapter()?.getCurrentFragmentAt(it.position)?.onSearchQueryChanged(
+                        text = binding.mainMenu.getCurrentQuery()
+                    )
+                }
             }
         )
 
@@ -335,7 +338,7 @@ class MainActivity : SimpleMusicActivity() {
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, resultData: Intent?) {
         super.onActivityResult(requestCode, resultCode, resultData)
-        if (requestCode == PICK_IMPORT_SOURCE_INTENT && resultCode == Activity.RESULT_OK && resultData != null && resultData.data != null) {
+        if (requestCode == PICK_IMPORT_SOURCE_INTENT && resultCode == RESULT_OK && resultData != null && resultData.data != null) {
             tryImportPlaylistFromFile(resultData.data!!)
         }
     }

--- a/app/src/main/kotlin/org/fossify/musicplayer/adapters/ViewPagerAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/adapters/ViewPagerAdapter.kt
@@ -1,5 +1,6 @@
 package org.fossify.musicplayer.adapters
 
+import android.util.SparseArray
 import android.view.View
 import android.view.ViewGroup
 import androidx.viewpager.widget.PagerAdapter
@@ -15,11 +16,13 @@ import org.fossify.musicplayer.helpers.*
 
 class ViewPagerAdapter(val activity: SimpleActivity) : PagerAdapter() {
     private val fragments = arrayListOf<MyViewPagerFragment>()
+    private val items = SparseArray<MyViewPagerFragment>()
     private var primaryItem: MyViewPagerFragment? = null
 
     override fun instantiateItem(container: ViewGroup, position: Int): Any {
         return getFragment(position, container).apply {
             fragments.add(this)
+            items.put(position, this)
             container.addView(this)
             setupFragment(activity)
             setupColors(activity.getProperTextColor(), activity.getProperPrimaryColor())
@@ -28,6 +31,7 @@ class ViewPagerAdapter(val activity: SimpleActivity) : PagerAdapter() {
 
     override fun destroyItem(container: ViewGroup, position: Int, item: Any) {
         fragments.remove(item)
+        items.remove(position)
         container.removeView(item as View)
     }
 
@@ -56,6 +60,8 @@ class ViewPagerAdapter(val activity: SimpleActivity) : PagerAdapter() {
     fun getAllFragments() = fragments
 
     fun getCurrentFragment() = primaryItem
+
+    fun getCurrentFragmentAt(position: Int): MyViewPagerFragment? = items.get(position)
 
     fun getPlaylistsFragment() = fragments.find { it is PlaylistsFragment }
 

--- a/app/src/main/kotlin/org/fossify/musicplayer/adapters/ViewPagerAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/adapters/ViewPagerAdapter.kt
@@ -20,7 +20,19 @@ class ViewPagerAdapter(val activity: SimpleActivity) : PagerAdapter() {
     private var primaryItem: MyViewPagerFragment? = null
 
     override fun instantiateItem(container: ViewGroup, position: Int): Any {
-        return getFragment(position, container).apply {
+        val tab = activity.getVisibleTabs()[position]
+        val layoutInflater = activity.layoutInflater
+        val fragment =  when (tab) {
+            TAB_PLAYLISTS -> FragmentPlaylistsBinding.inflate(layoutInflater, container, false).root
+            TAB_FOLDERS -> FragmentFoldersBinding.inflate(layoutInflater, container, false).root
+            TAB_ARTISTS -> FragmentArtistsBinding.inflate(layoutInflater, container, false).root
+            TAB_ALBUMS -> FragmentAlbumsBinding.inflate(layoutInflater, container, false).root
+            TAB_TRACKS -> FragmentTracksBinding.inflate(layoutInflater, container, false).root
+            TAB_GENRES -> FragmentGenresBinding.inflate(layoutInflater, container, false).root
+            else -> throw IllegalArgumentException("Unknown tab: $tab")
+        }
+
+        return fragment.apply {
             fragments.add(this)
             items.put(position, this)
             container.addView(this)
@@ -43,25 +55,11 @@ class ViewPagerAdapter(val activity: SimpleActivity) : PagerAdapter() {
 
     override fun isViewFromObject(view: View, item: Any) = view == item
 
-    private fun getFragment(position: Int, container: ViewGroup): MyViewPagerFragment {
-        val tab = activity.getVisibleTabs()[position]
-        val layoutInflater = activity.layoutInflater
-        return when (tab) {
-            TAB_PLAYLISTS -> FragmentPlaylistsBinding.inflate(layoutInflater, container, false).root
-            TAB_FOLDERS -> FragmentFoldersBinding.inflate(layoutInflater, container, false).root
-            TAB_ARTISTS -> FragmentArtistsBinding.inflate(layoutInflater, container, false).root
-            TAB_ALBUMS -> FragmentAlbumsBinding.inflate(layoutInflater, container, false).root
-            TAB_TRACKS -> FragmentTracksBinding.inflate(layoutInflater, container, false).root
-            TAB_GENRES -> FragmentGenresBinding.inflate(layoutInflater, container, false).root
-            else -> throw IllegalArgumentException("Unknown tab: $tab")
-        }
-    }
-
     fun getAllFragments() = fragments
 
     fun getCurrentFragment() = primaryItem
 
-    fun getCurrentFragmentAt(position: Int): MyViewPagerFragment? = items.get(position)
+    fun getFragmentAt(position: Int): MyViewPagerFragment? = items.get(position)
 
     fun getPlaylistsFragment() = fragments.find { it is PlaylistsFragment }
 


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Search query is now preserved during tab change. Added a `getFragmentAt()` method for it because `getCurrentFragment()` can be outdated due to settling ViewPager state.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Searching and switching pages by swiping
 - Searching and switching pages manually using the tab buttons

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Music-Player/issues/261

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
