### PR TITLE
feat: add support for folders on Android 9 and below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for folders on Android 9 and below versions ([#258])
 
 ## [1.3.0] - 2025-10-09
 ### Changed
@@ -66,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#206]: https://github.com/FossifyOrg/Music-Player/issues/206
 [#209]: https://github.com/FossifyOrg/Music-Player/issues/209
 [#228]: https://github.com/FossifyOrg/Music-Player/issues/228
+[#258]: https://github.com/FossifyOrg/Music-Player/issues/258
 [#261]: https://github.com/FossifyOrg/Music-Player/issues/261
 [#269]: https://github.com/FossifyOrg/Music-Player/issues/269
 

--- a/app/src/main/kotlin/org/fossify/musicplayer/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/activities/SettingsActivity.kt
@@ -6,7 +6,6 @@ import org.fossify.commons.dialogs.RadioGroupDialog
 import org.fossify.commons.extensions.*
 import org.fossify.commons.helpers.IS_CUSTOMIZING_COLORS
 import org.fossify.commons.helpers.NavigationIcon
-import org.fossify.commons.helpers.isQPlus
 import org.fossify.commons.helpers.isTiramisuPlus
 import org.fossify.commons.models.RadioItem
 import org.fossify.musicplayer.R
@@ -134,7 +133,6 @@ class SettingsActivity : SimpleControllerActivity() {
     }
 
     private fun setupManageExcludedFolders() {
-        binding.settingsManageExcludedFoldersHolder.beVisibleIf(isQPlus())
         binding.settingsManageExcludedFoldersHolder.setOnClickListener {
             startActivity(Intent(this, ExcludedFoldersActivity::class.java))
         }

--- a/app/src/main/kotlin/org/fossify/musicplayer/dialogs/ManageVisibleTabsDialog.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/dialogs/ManageVisibleTabsDialog.kt
@@ -1,11 +1,9 @@
 package org.fossify.musicplayer.dialogs
 
 import org.fossify.commons.activities.BaseSimpleActivity
-import org.fossify.commons.extensions.beGone
 import org.fossify.commons.extensions.getAlertDialogBuilder
 import org.fossify.commons.extensions.setupDialogStuff
 import org.fossify.commons.extensions.viewBinding
-import org.fossify.commons.helpers.isQPlus
 import org.fossify.commons.views.MyAppCompatCheckbox
 import org.fossify.musicplayer.databinding.DialogManageVisibleTabsBinding
 import org.fossify.musicplayer.extensions.config
@@ -23,11 +21,6 @@ class ManageVisibleTabsDialog(val activity: BaseSimpleActivity, val callback: (r
             put(TAB_ALBUMS, binding.manageVisibleTabsAlbums)
             put(TAB_TRACKS, binding.manageVisibleTabsTracks)
             put(TAB_GENRES, binding.manageVisibleTabsGenres)
-        }
-
-        if (!isQPlus()) {
-            tabs.remove(TAB_FOLDERS)
-            binding.manageVisibleTabsFolders.beGone()
         }
 
         val showTabs = activity.config.showTabs
@@ -52,7 +45,7 @@ class ManageVisibleTabsDialog(val activity: BaseSimpleActivity, val callback: (r
         }
 
         if (result == 0) {
-            result = allTabsMask
+            result = ALL_TABS_MASK
         }
 
         callback(result)

--- a/app/src/main/kotlin/org/fossify/musicplayer/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/extensions/Context.kt
@@ -297,3 +297,11 @@ fun Context.getPlaybackSetting(repeatMode: @Player.RepeatMode Int): PlaybackSett
         else -> config.playbackSetting
     }
 }
+
+fun Context.getFriendlyFolder(path: String): String {
+    return when (val parentPath = path.getParentPath()) {
+        internalStoragePath -> getString(org.fossify.commons.R.string.internal)
+        sdCardPath -> getString(org.fossify.commons.R.string.sd_card)
+        else -> parentPath.getFilenameFromPath()
+    }
+}

--- a/app/src/main/kotlin/org/fossify/musicplayer/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/helpers/Config.kt
@@ -2,7 +2,6 @@ package org.fossify.musicplayer.helpers
 
 import android.content.Context
 import org.fossify.commons.helpers.BaseConfig
-import java.util.Arrays
 
 class Config(context: Context) : BaseConfig(context) {
     companion object {
@@ -116,7 +115,7 @@ class Config(context: Context) : BaseConfig(context) {
             .apply()
 
     var showTabs: Int
-        get() = prefs.getInt(SHOW_TABS, allTabsMask)
+        get() = prefs.getInt(SHOW_TABS, ALL_TABS_MASK)
         set(showTabs) = prefs.edit().putInt(SHOW_TABS, showTabs).apply()
 
     var excludedFolders: MutableSet<String>
@@ -124,7 +123,7 @@ class Config(context: Context) : BaseConfig(context) {
         set(excludedFolders) = prefs.edit().remove(EXCLUDED_FOLDERS).putStringSet(EXCLUDED_FOLDERS, excludedFolders).apply()
 
     fun addExcludedFolder(path: String) {
-        addExcludedFolders(HashSet(Arrays.asList(path)))
+        addExcludedFolders(HashSet(listOf(path)))
     }
 
     fun addExcludedFolders(paths: Set<String>) {

--- a/app/src/main/kotlin/org/fossify/musicplayer/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/helpers/Constants.kt
@@ -3,7 +3,6 @@ package org.fossify.musicplayer.helpers
 import androidx.core.net.toUri
 import org.fossify.commons.helpers.PERMISSION_READ_MEDIA_AUDIO
 import org.fossify.commons.helpers.PERMISSION_WRITE_STORAGE
-import org.fossify.commons.helpers.isQPlus
 import org.fossify.commons.helpers.isTiramisuPlus
 
 const val ALL_TRACKS_PLAYLIST_ID = 1
@@ -83,32 +82,17 @@ const val ACTIVITY_PLAYLIST_FOLDER = 64
 const val FLAG_MANUAL_CACHE = 1
 const val FLAG_IS_CURRENT = 2
 
-// show Folders tab only on Android Q+, BUCKET_DISPLAY_NAME hasn't been available before that
-val allTabsMask = if (isQPlus()) {
-    TAB_PLAYLISTS or TAB_FOLDERS or TAB_ARTISTS or TAB_ALBUMS or TAB_TRACKS
-} else {
-    TAB_PLAYLISTS or TAB_ARTISTS or TAB_ALBUMS or TAB_TRACKS
-}
+const val ALL_TABS_MASK = TAB_PLAYLISTS or TAB_FOLDERS or TAB_ARTISTS or TAB_ALBUMS or TAB_TRACKS
 
 val tabsList: ArrayList<Int>
-    get() = if (isQPlus()) {
-        arrayListOf(
-            TAB_PLAYLISTS,
-            TAB_FOLDERS,
-            TAB_ARTISTS,
-            TAB_ALBUMS,
-            TAB_TRACKS,
-            TAB_GENRES
-        )
-    } else {
-        arrayListOf(
-            TAB_PLAYLISTS,
-            TAB_ARTISTS,
-            TAB_ALBUMS,
-            TAB_TRACKS,
-            TAB_GENRES
-        )
-    }
+    get() = arrayListOf(
+        TAB_PLAYLISTS,
+        TAB_FOLDERS,
+        TAB_ARTISTS,
+        TAB_ALBUMS,
+        TAB_TRACKS,
+        TAB_GENRES
+    )
 
 // use custom sorting constants, there are too many app specific ones
 const val PLAYER_SORT_BY_TITLE = 1

--- a/app/src/main/kotlin/org/fossify/musicplayer/helpers/SimpleMediaScanner.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/helpers/SimpleMediaScanner.kt
@@ -19,6 +19,7 @@ import org.fossify.musicplayer.models.*
 import java.io.File
 import java.io.FileInputStream
 import androidx.core.net.toUri
+import org.fossify.musicplayer.extensions.getFriendlyFolder
 
 /**
  * This singleton class manages the process of querying [MediaStore] for new audio files, manually scanning storage for missing audio files, and removing outdated
@@ -239,7 +240,7 @@ class SimpleMediaScanner(private val context: Application) {
             val folderName = if (isQPlus()) {
                 cursor.getStringValue(Audio.Media.BUCKET_DISPLAY_NAME) ?: MediaStore.UNKNOWN_STRING
             } else {
-                ""
+                context.getFriendlyFolder(path).ifEmpty { MediaStore.UNKNOWN_STRING }
             }
 
             val album = cursor.getStringValue(Audio.Media.ALBUM) ?: folderName


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Added support for folders on Android 8 and 9.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested playing audio files from various folders on Android 9
 - Tested folder exclusion on different Android versions

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Music-Player/issues/258

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
