### PR TITLE
fix: use player thread for player calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed player crash when clearing app from recents ([#298])
 
 ## [1.5.0] - 2025-10-29
 ### Changed
@@ -81,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#258]: https://github.com/FossifyOrg/Music-Player/issues/258
 [#261]: https://github.com/FossifyOrg/Music-Player/issues/261
 [#269]: https://github.com/FossifyOrg/Music-Player/issues/269
+[#298]: https://github.com/FossifyOrg/Music-Player/issues/298
 
 [Unreleased]: https://github.com/FossifyOrg/Music-Player/compare/1.5.0...HEAD
 [1.5.0]: https://github.com/FossifyOrg/Music-Player/compare/1.4.0...1.5.0

--- a/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
@@ -33,7 +33,6 @@ import org.fossify.musicplayer.playback.CustomCommands
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import java.io.File
 import java.io.FileOutputStream
 
 class MainActivity : SimpleMusicActivity() {

--- a/app/src/main/kotlin/org/fossify/musicplayer/playback/PlaybackService.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/playback/PlaybackService.kt
@@ -1,5 +1,6 @@
 package org.fossify.musicplayer.playback
 
+import android.content.Intent
 import android.os.Handler
 import android.os.HandlerThread
 import android.os.Looper
@@ -75,7 +76,9 @@ class PlaybackService : MediaLibraryService(), MediaSessionService.Listener {
         }
     }
 
-    internal fun withPlayer(callback: SimpleMusicPlayer.() -> Unit) = playerHandler.post { callback(player) }
+    internal fun withPlayer(callback: SimpleMusicPlayer.() -> Unit) {
+        playerHandler.post { callback(player) }
+    }
 
     private fun showNoPermissionNotification() {
         Handler(Looper.getMainLooper()).postDelayed(delayInMillis = 100L) {
@@ -97,6 +100,12 @@ class PlaybackService : MediaLibraryService(), MediaSessionService.Listener {
     override fun onForegroundServiceStartNotAllowedException() {
         showErrorToast(getString(org.fossify.commons.R.string.unknown_error_occurred))
         // todo: show a notification instead.
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        playerHandler.post {
+            super.onTaskRemoved(rootIntent)
+        }
     }
 
     companion object {


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Added `onTaskRemoved()` override to ensure internal calls to the player are done on the player thread. This is a quick fix for what appears to be a bug in media3 implementation (internal calls shouldn't assume the player runs on the main thread).

The whole _keep player on background thread_ thing needs to be revisited.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Playing, seeking items, closing app by clearing from recents

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Music-Player/issues/298

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
