### PR TITLE
fix: apply proper insets when only one tab is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed player crash when clearing app from recents ([#298])
+- Fixed overlap between current track and system bars
 
 ## [1.5.0] - 2025-10-29
 ### Changed

--- a/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
@@ -52,7 +52,14 @@ class MainActivity : SimpleMusicActivity() {
         appLaunched(BuildConfig.APPLICATION_ID)
         setupOptionsMenu()
         refreshMenuItems()
-        setupEdgeToEdge(padBottomImeAndSystem = listOf(binding.mainTabsHolder))
+        setupEdgeToEdge(
+            padBottomImeAndSystem = buildList {
+                add(binding.mainTabsHolder)
+                if (getVisibleTabs().size == 1) {
+                    add(binding.currentTrackBar.root)
+                }
+            }
+        )
         storeStateVariables()
         setupTabs()
         setupCurrentTrackBar(binding.currentTrackBar.root)

--- a/app/src/main/kotlin/org/fossify/musicplayer/activities/SimpleMusicActivity.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/activities/SimpleMusicActivity.kt
@@ -32,7 +32,11 @@ abstract class SimpleMusicActivity : SimpleControllerActivity(), Player.Listener
                         startActivity(this)
                     }
                 } else {
-                    PermissionRequiredDialog(this, org.fossify.commons.R.string.allow_notifications_music_player, { openNotificationSettings() })
+                    PermissionRequiredDialog(
+                        activity = this,
+                        textId = org.fossify.commons.R.string.allow_notifications_music_player,
+                        positiveActionCallback = { openNotificationSettings() }
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/org/fossify/musicplayer/views/CurrentTrackBar.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/views/CurrentTrackBar.kt
@@ -3,7 +3,6 @@ package org.fossify.musicplayer.views
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
-import android.graphics.drawable.ColorDrawable
 import android.provider.MediaStore
 import android.util.AttributeSet
 import android.widget.RelativeLayout
@@ -16,6 +15,7 @@ import org.fossify.commons.extensions.*
 import org.fossify.musicplayer.R
 import org.fossify.musicplayer.databinding.ViewCurrentTrackBarBinding
 import org.fossify.musicplayer.extensions.*
+import androidx.core.graphics.drawable.toDrawable
 
 class CurrentTrackBar(context: Context, attributeSet: AttributeSet) : RelativeLayout(context, attributeSet) {
     private val binding by viewBinding(ViewCurrentTrackBarBinding::bind)
@@ -27,7 +27,7 @@ class CurrentTrackBar(context: Context, attributeSet: AttributeSet) : RelativeLa
     }
 
     fun updateColors() {
-        background = ColorDrawable(context.getProperBackgroundColor())
+        background = context.getProperBackgroundColor().toDrawable()
         binding.currentTrackLabel.setTextColor(context.getProperTextColor())
     }
 


### PR DESCRIPTION
Partially addresses https://github.com/FossifyOrg/General-Discussion/issues/749