### PR TITLE
perf: resolve media items as soon as possible

### DIFF
--- a/app/src/main/kotlin/org/fossify/musicplayer/activities/TrackActivity.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/activities/TrackActivity.kt
@@ -70,7 +70,7 @@ import kotlin.time.Duration.Companion.milliseconds
 class TrackActivity : SimpleControllerActivity(), PlaybackSpeedListener {
     companion object {
         private const val SWIPE_DOWN_THRESHOLD = 100
-        private const val SEEK_COALESCE_INTERVAL_MS = 200L
+        private const val SEEK_COALESCE_INTERVAL_MS = 150L
         private const val UPDATE_INTERVAL_MS = 150L
     }
 

--- a/app/src/main/kotlin/org/fossify/musicplayer/playback/MediaSessionCallback.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/playback/MediaSessionCallback.kt
@@ -194,7 +194,7 @@ internal fun PlaybackService.getMediaSessionCallback() = object : MediaLibrarySe
         controller: MediaSession.ControllerInfo,
         mediaItems: List<MediaItem>
     ): ListenableFuture<List<MediaItem>> {
-        return callWhenSourceReady {
+        return executorService.submit<List<MediaItem>> {
             val items = mediaItems.map { mediaItem ->
                 if (mediaItem.requestMetadata.searchQuery != null) {
                     getMediaItemFromSearchQuery(mediaItem.requestMetadata.searchQuery!!)


### PR DESCRIPTION
No need to wait for the whole tree to be initialized for adding media items.
