### PR TITLE
Part 1/2 fixing sleeptimer change

### DIFF
--- a/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
@@ -468,6 +468,8 @@ class MainActivity : SimpleMusicActivity() {
                 }
             } else if (it > 0) {
                 pickedSleepTimer(it)
+            } else if (config.lastSleepTimerSeconds > 0) {
+                sleepTimerChanged(Events.SleepTimerChanged(seconds = it))
             }
         }
     }
@@ -500,10 +502,10 @@ class MainActivity : SimpleMusicActivity() {
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun sleepTimerChanged(event: Events.SleepTimerChanged) {
-        binding.sleepTimerValue.text = event.seconds.getFormattedDuration()
-        binding.sleepTimerHolder.beVisible()
-
-        if (event.seconds == 0) {
+        if (event.seconds > 0) {
+            binding.sleepTimerValue.text = event.seconds.getFormattedDuration()
+            binding.sleepTimerHolder.beVisible()
+        } else {
             finish()
         }
     }


### PR DESCRIPTION
First file of two to be edited to fix this bug: https://github.com/FossifyOrg/Music-Player/issues/345

This request affect the file MainActivity.kt

sleepTimerChanged wasn't used so I added it in the showSleepTimer under the condition that it is called if the value of sleeptimer is above 0. Also in sleepTimerChanged I put the two binding under a if condition checking if the value of the sleeptimer it above 0,, otherwise if it is 0 it is left to finish but could be uneccessary because the function shouldn't be called if the timer is already at 0.

Sorry for making the fix in two pull request I'm still new to this, next request is final and will only affect the file: SleepTimer.kt

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Fix in MainActivity.kt to call sleepTimerChanged
- Slight change to sleepTimerChanged's logic though could be a useless change

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested on Android Studio, changing the timer went as expected. First timer is switched to the newly selected timer and doing so no longer crash the app.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Closes #345 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
