### PR TITLE
fix: keep the active search filter after deleting a track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed search results resetting to the full song list after deleting a track while searching ([#85])
 
 ## [1.8.1] - 2026-02-14
 ### Changed
@@ -115,6 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#47]: https://github.com/FossifyOrg/Music-Player/issues/47
 [#65]: https://github.com/FossifyOrg/Music-Player/issues/65
 [#69]: https://github.com/FossifyOrg/Music-Player/issues/69
+[#85]: https://github.com/FossifyOrg/Music-Player/issues/85
 [#97]: https://github.com/FossifyOrg/Music-Player/issues/97
 [#179]: https://github.com/FossifyOrg/Music-Player/issues/179
 [#206]: https://github.com/FossifyOrg/Music-Player/issues/206

--- a/app/src/main/kotlin/org/fossify/musicplayer/fragments/TracksFragment.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/fragments/TracksFragment.kt
@@ -23,6 +23,7 @@ import org.fossify.musicplayer.models.sortSafely
 // Artists -> Albums -> Tracks
 class TracksFragment(context: Context, attributeSet: AttributeSet) : MyViewPagerFragment(context, attributeSet) {
     private var tracks = ArrayList<Track>()
+    private var lastSearchQuery = ""
     private val binding by viewBinding(FragmentTracksBinding::bind)
 
     override fun setupFragment(activity: BaseSimpleActivity) {
@@ -70,6 +71,12 @@ class TracksFragment(context: Context, attributeSet: AttributeSet) : MyViewPager
                 } else {
                     (adapter as TracksAdapter).updateItems(tracks)
                 }
+
+                // re-apply the active search filter so it isn't lost after a refresh
+                // (e.g. when deleting a track while searching)
+                if (lastSearchQuery.isNotEmpty()) {
+                    onSearchQueryChanged(lastSearchQuery)
+                }
             }
         }
     }
@@ -79,6 +86,7 @@ class TracksFragment(context: Context, attributeSet: AttributeSet) : MyViewPager
     }
 
     override fun onSearchQueryChanged(text: String) {
+        lastSearchQuery = text
         val normalizedText = text.normalizeString()
         val filtered = ArrayList(
             tracks.filter { track ->
@@ -93,6 +101,7 @@ class TracksFragment(context: Context, attributeSet: AttributeSet) : MyViewPager
     }
 
     override fun onSearchClosed() {
+        lastSearchQuery = ""
         getAdapter()?.updateItems(tracks)
         binding.tracksPlaceholder.beGoneIf(tracks.isNotEmpty())
     }


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
When you search on the Tracks tab and then delete one of the matching tracks, the visible list would reset to the entire library instead of staying filtered.

Deleting a selected track posts `Events.RefreshFragments()`. `MainActivity.shouldRefreshFragments()` then calls `refreshAllFragments()`, which re-runs `TracksFragment.setupFragment()`. That method reloads the full library on a background thread and, back on the UI thread, calls `updateItems(tracks)` with the complete, unfiltered list and an empty highlight string. The search bar itself stays open (the query is still held by `MySearchMenu`), but the fragment never re-applies it, so the user is shown the whole library again.

The fix tracks the active query in a new `lastSearchQuery` field (set in `onSearchQueryChanged`, cleared in `onSearchClosed`) and, after the async reload finishes and the adapter is updated, re-applies the filter by calling `onSearchQueryChanged(lastSearchQuery)` when a query is still active. The filtered view (minus the deleted track) is now preserved.

#### Tests performed
- `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).
- Source-verified: the tracks list now remembers the active search query and re-applies it after a refresh (e.g. following a delete), so search results are no longer replaced by the full library.
- Note: verified via CI + code review; the search-then-delete UI flow was not scripted end-to-end.

#### Closes the following issue(s)
- Closes #85

#### Checklist
- [x] I read the contribution guidelines.
- [ ] I manually tested my changes on device/emulator (verified via CI + source review; see Tests performed).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
