### PR TITLE
fix: prevent a crash when cancelling the sleep timer after a reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed the sleep timer freezing and the app closing when the timer was set again and then canceled ([#345])
 
 ## [1.8.1] - 2026-02-14
 ### Changed
@@ -124,6 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#261]: https://github.com/FossifyOrg/Music-Player/issues/261
 [#269]: https://github.com/FossifyOrg/Music-Player/issues/269
 [#298]: https://github.com/FossifyOrg/Music-Player/issues/298
+[#345]: https://github.com/FossifyOrg/Music-Player/issues/345
 [#361]: https://github.com/FossifyOrg/Music-Player/issues/361
 
 [Unreleased]: https://github.com/FossifyOrg/Music-Player/compare/1.8.1...HEAD

--- a/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/activities/MainActivity.kt
@@ -481,14 +481,14 @@ class MainActivity : SimpleMusicActivity() {
     private fun startSleepTimer() {
         binding.sleepTimerHolder.fadeIn()
         withPlayer {
-            sendCommand(CustomCommands.TOGGLE_SLEEP_TIMER)
+            sendCommand(CustomCommands.START_SLEEP_TIMER)
         }
     }
 
     private fun stopSleepTimer() {
         binding.sleepTimerHolder.fadeOut()
         withPlayer {
-            sendCommand(CustomCommands.TOGGLE_SLEEP_TIMER)
+            sendCommand(CustomCommands.STOP_SLEEP_TIMER)
         }
     }
 

--- a/app/src/main/kotlin/org/fossify/musicplayer/playback/CustomCommands.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/playback/CustomCommands.kt
@@ -12,7 +12,8 @@ import org.fossify.musicplayer.helpers.PATH
 enum class CustomCommands(val customAction: String) {
     CLOSE_PLAYER(customAction = PATH + "CLOSE_PLAYER"),
     RELOAD_CONTENT(customAction = PATH + "RELOAD_CONTENT"),
-    TOGGLE_SLEEP_TIMER(customAction = PATH + "TOGGLE_SLEEP_TIMER"),
+    START_SLEEP_TIMER(customAction = PATH + "START_SLEEP_TIMER"),
+    STOP_SLEEP_TIMER(customAction = PATH + "STOP_SLEEP_TIMER"),
     SET_NEXT_ITEM(customAction = PATH + "SET_NEXT_ITEM"),
     SET_SHUFFLE_ORDER(customAction = PATH + "SET_SHUFFLE_ORDER");
 

--- a/app/src/main/kotlin/org/fossify/musicplayer/playback/MediaSessionCallback.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/playback/MediaSessionCallback.kt
@@ -74,7 +74,8 @@ internal fun PlaybackService.getMediaSessionCallback() = object : MediaLibrarySe
         when (command) {
             CustomCommands.CLOSE_PLAYER -> stopService()
             CustomCommands.RELOAD_CONTENT -> reloadContent()
-            CustomCommands.TOGGLE_SLEEP_TIMER -> toggleSleepTimer()
+            CustomCommands.START_SLEEP_TIMER -> startSleepTimer()
+            CustomCommands.STOP_SLEEP_TIMER -> stopSleepTimer()
             CustomCommands.SET_SHUFFLE_ORDER -> setShuffleOrder(args)
             CustomCommands.SET_NEXT_ITEM -> setNextItem(args)
         }

--- a/app/src/main/kotlin/org/fossify/musicplayer/playback/SleepTimer.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/playback/SleepTimer.kt
@@ -5,16 +5,7 @@ import org.fossify.musicplayer.extensions.config
 import org.fossify.musicplayer.models.Events
 import org.greenrobot.eventbus.EventBus
 
-private var isActive = false
 private var sleepTimer: CountDownTimer? = null
-
-internal fun PlaybackService.toggleSleepTimer() {
-    if (isActive) {
-        stopSleepTimer()
-    } else {
-        startSleepTimer()
-    }
-}
 
 internal fun PlaybackService.startSleepTimer() {
     val millisInFuture = config.sleepInTS - System.currentTimeMillis() + 1000L
@@ -34,12 +25,10 @@ internal fun PlaybackService.startSleepTimer() {
     }
 
     sleepTimer?.start()
-    isActive = true
 }
 
 internal fun PlaybackService.stopSleepTimer() {
     sleepTimer?.cancel()
     sleepTimer = null
-    isActive = false
     config.sleepInTS = 0
 }


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
The sleep timer was driven by a single `TOGGLE_SLEEP_TIMER` custom command whose behavior depended on a service-side `isActive` boolean. `MainActivity` sent the **same** toggle command for both "set timer" (`startSleepTimer`) and "cancel" (`stopSleepTimer`), which only works while the client intent and the service `isActive` state stay in sync.

Setting the timer a second time desynced them: the second "set" toggled the timer **off** instead of restarting it (canceling the countdown and zeroing `config.sleepInTS`, so the visible countdown froze). A subsequent tap on the stop button then toggled the timer back **on**, building a `CountDownTimer` from the stale, zeroed timestamp. That yielded a non-positive `millisInFuture`, so `CountDownTimer.start()` fired `onFinish()` immediately, posting `Events.SleepTimerChanged(0)`; `MainActivity.sleepTimerChanged()` sees `seconds == 0` and calls `finish()`, so the app exits.

This fix splits the ambiguous toggle into explicit `START_SLEEP_TIMER` and `STOP_SLEEP_TIMER` commands so that "set" always (re)starts the timer and "cancel" always stops it. The service-side `isActive` flag and the `toggleSleepTimer()` indirection are removed since they are no longer needed. This addresses both reported symptoms (the countdown freezing when the timer is set again, and the app closing when it is then canceled).

#### Tests performed
- `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).
- Source-verified: sleep-timer start/stop are now routed through MediaSession custom commands (`START_SLEEP_TIMER` / `STOP_SLEEP_TIMER`) so cancelling after a reset no longer references a stale timer and crashes.
- Note: the precise reset-then-cancel race is impractical to stage deterministically on the emulator; verified via CI + code review.

#### Closes the following issue(s)
- Closes #345

#### Checklist
- [x] I read the contribution guidelines.
- [ ] I manually tested my changes on device/emulator (verified via CI + source review; see Tests performed).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
