### PR TITLE
Add filename option to Tracks Sort by dialog

### DIFF
--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -18,6 +18,7 @@
     <ID>ImplicitDefaultLocale:PlaybackSpeedFragment.kt$PlaybackSpeedFragment$String.format("%.2f", value)</ID>
     <ID>MagicNumber:ChangeSortingDialog.kt$ChangeSortingDialog$3</ID>
     <ID>MagicNumber:ChangeSortingDialog.kt$ChangeSortingDialog$4</ID>
+    <ID>MagicNumber:ChangeSortingDialog.kt$ChangeSortingDialog$5</ID>
     <ID>MagicNumber:Config.kt$Config$30</ID>
     <ID>MagicNumber:Config.kt$Config$60</ID>
     <ID>MagicNumber:EqualizerActivity.kt$EqualizerActivity$100</ID>
@@ -74,6 +75,7 @@
     <ID>MaxLineLength:ChangeSortingDialog.kt$ChangeSortingDialog$radioItems.add(RadioItem(2, activity.getString(org.fossify.commons.R.string.duration), PLAYER_SORT_BY_DURATION))</ID>
     <ID>MaxLineLength:ChangeSortingDialog.kt$ChangeSortingDialog$radioItems.add(RadioItem(4, activity.getString(org.fossify.commons.R.string.custom), PLAYER_SORT_BY_CUSTOM))</ID>
     <ID>MaxLineLength:ChangeSortingDialog.kt$ChangeSortingDialog$radioItems.add(RadioItem(4, activity.getString(org.fossify.commons.R.string.date_added), PLAYER_SORT_BY_DATE_ADDED))</ID>
+    <ID>MaxLineLength:ChangeSortingDialog.kt$ChangeSortingDialog$radioItems.add(RadioItem(5, activity.getString(org.fossify.commons.R.string.filename), PLAYER_SORT_BY_FILENAME))</ID>
     <ID>MaxLineLength:Config.kt$Config$set(excludedFolders) = prefs.edit().remove(EXCLUDED_FOLDERS).putStringSet(EXCLUDED_FOLDERS, excludedFolders).apply()</ID>
     <ID>MaxLineLength:Config.kt$Config$set(wasAllTracksPlaylistCreated) = prefs.edit().putBoolean(WAS_ALL_TRACKS_PLAYLIST_CREATED, wasAllTracksPlaylistCreated).apply()</ID>
     <ID>MaxLineLength:Context.kt$&lt;no name provided&gt;$override</ID>

--- a/app/src/main/kotlin/org/fossify/musicplayer/dialogs/ChangeSortingDialog.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/dialogs/ChangeSortingDialog.kt
@@ -88,6 +88,7 @@ class ChangeSortingDialog(val activity: Activity, val location: Int, val playlis
                 radioItems.add(RadioItem(2, activity.getString(org.fossify.commons.R.string.duration), PLAYER_SORT_BY_DURATION))
                 radioItems.add(RadioItem(3, activity.getString(R.string.track_number), PLAYER_SORT_BY_TRACK_ID))
                 radioItems.add(RadioItem(4, activity.getString(org.fossify.commons.R.string.date_added), PLAYER_SORT_BY_DATE_ADDED))
+                radioItems.add(RadioItem(5, activity.getString(org.fossify.commons.R.string.filename), PLAYER_SORT_BY_FILENAME))
             }
 
             TAB_GENRES -> {
@@ -101,6 +102,7 @@ class ChangeSortingDialog(val activity: Activity, val location: Int, val playlis
                 radioItems.add(RadioItem(2, activity.getString(org.fossify.commons.R.string.duration), PLAYER_SORT_BY_DURATION))
                 radioItems.add(RadioItem(3, activity.getString(R.string.track_number), PLAYER_SORT_BY_TRACK_ID))
                 radioItems.add(RadioItem(4, activity.getString(org.fossify.commons.R.string.date_added), PLAYER_SORT_BY_DATE_ADDED))
+                radioItems.add(RadioItem(5, activity.getString(org.fossify.commons.R.string.filename), PLAYER_SORT_BY_FILENAME))
 
                 if (playlist != null) {
                     radioItems.add(RadioItem(4, activity.getString(org.fossify.commons.R.string.custom), PLAYER_SORT_BY_CUSTOM))

--- a/app/src/main/kotlin/org/fossify/musicplayer/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/helpers/Constants.kt
@@ -107,6 +107,7 @@ const val PLAYER_SORT_BY_ARTIST_TITLE = 32
 const val PLAYER_SORT_BY_TRACK_ID = 64
 const val PLAYER_SORT_BY_CUSTOM = 128
 const val PLAYER_SORT_BY_DATE_ADDED = 256
+const val PLAYER_SORT_BY_FILENAME = 512
 
 const val PLAYLIST_SORTING = "playlist_sorting"
 const val PLAYLIST_TRACKS_SORTING = "playlist_tracks_sorting"

--- a/app/src/main/kotlin/org/fossify/musicplayer/models/Track.kt
+++ b/app/src/main/kotlin/org/fossify/musicplayer/models/Track.kt
@@ -72,6 +72,11 @@ data class Track(
                     }
                 }
                 sorting and PLAYER_SORT_BY_DATE_ADDED != 0 -> first.dateAdded.compareTo(second.dateAdded)
+                sorting and PLAYER_SORT_BY_FILENAME != 0 -> {
+                    AlphanumericComparator().compare(
+                        first.path.getFilenameFromPath().lowercase(), second.path.getFilenameFromPath().lowercase()
+                    )
+                }
                 sorting and PLAYER_SORT_BY_CUSTOM != 0 -> first.orderInPlaylist.compareTo(second.orderInPlaylist)
                 else -> first.duration.compareTo(second.duration)
             }
@@ -87,6 +92,7 @@ data class Track(
     fun getBubbleText(sorting: Int) = when {
         sorting and PLAYER_SORT_BY_TITLE != 0 -> title
         sorting and PLAYER_SORT_BY_ARTIST_TITLE != 0 -> artist
+        sorting and PLAYER_SORT_BY_FILENAME != 0 -> path.getFilenameFromPath()
         else -> duration.getFormattedDuration()
     }
 


### PR DESCRIPTION
Adds a File name choice to the Tracks (and playlist/folder) Sort by dialog so tracks can be sorted by filename without forcing the "show filename as song title" setting.

Fixes #393

## Test plan
- [ ] Open Tracks tab → Sort by → File name appears
- [ ] Sort ascending/descending by filename
- [ ] Same option in a playlist/folder track list
